### PR TITLE
Add ducci sequence program

### DIFF
--- a/math/ducci.py
+++ b/math/ducci.py
@@ -1,0 +1,15 @@
+def ducci_sequence(*ns):
+    while True:
+        yield ns
+        ns = tuple(abs(ns[i - 1] - ns[i]) for i in range(len(ns)))
+
+def ducci(*ns):
+    known = set()
+    for ns in ducci_sequence(*ns):
+        print(ns)
+        if ns in known or set(ns) == {0}:
+            break
+        known.add(ns)
+    return len(known) + 1
+
+print(ducci(0, 653, 1854, 4063), "steps")


### PR DESCRIPTION
A Ducci sequence is a sequence of n-tuples of integers, sometimes known as "the Diffy game", because it is based on sequences. Given an n-tuple of integers (a_1, a_2, ... a_n) the next n-tuple in the sequence is formed by taking the absolute differences of neighboring integers. Ducci sequences are named after Enrico Ducci (1864-1940), the Italian mathematician credited with their discovery.

This program checks the number of steps taken for the given sequence to terminate.

### Usage

```
print(ducci(0, 653, 1854, 4063), "steps")
```